### PR TITLE
fix: 코스 정보 입력 시, '저장 완료" 텍스트가 제대로 노출/미노출이 안되는 이슈 해결

### DIFF
--- a/src/components/guide-generator/CourseEditor.tsx
+++ b/src/components/guide-generator/CourseEditor.tsx
@@ -204,7 +204,7 @@ const CourseEditor = () => {
         <p>코스 내용 작성하기 </p>
         <p>{isSaveComplete ? '자동저장 완료' : ''}</p>
       </div>
-      <p className="text-sm">정보를 수정할 때마다 2초 간격으로 자동 저장됩니다.</p>
+      <p className="text-sm">정보를 수정할 때마다 0.5초 간격으로 자동 저장됩니다.</p>
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(submitHandler)} className="mt-11 space-y-8">

--- a/src/components/guide-generator/CourseEditor.tsx
+++ b/src/components/guide-generator/CourseEditor.tsx
@@ -126,7 +126,8 @@ const CourseEditor = () => {
   useEffect(() => {
     const sub = form.watch((values) => {
       // 하이드레이션 끝나지 않았을 경우 무시
-      if (!hasHydrated.current || course.segments.length < 1) return;
+      // 혹은 사용자가 직접 값을 변경하지 않은 경우 (!form.formState.isDirty)
+      if (!hasHydrated.current || course.segments.length < 1 || !form.formState.isDirty) return;
 
       // 디바운스
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -147,17 +148,26 @@ const CourseEditor = () => {
         // 저장 완료 토스트 실행
         if (saveDoneTimerRef.current) clearTimeout(saveDoneTimerRef.current);
         setIsSaveComplete(true);
-        saveDoneTimerRef.current = setTimeout(() => {
-          setIsSaveComplete(false);
-        }, 1000);
-      }, 1000);
+      }, 500);
     });
     return () => {
       sub.unsubscribe();
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      if (saveDoneTimerRef.current) clearTimeout(saveDoneTimerRef.current);
     }
   }, [form, course.segments, saveCourse]);
+
+  // 저장 완료 여부 값에 대한 텍스트 노출 처리
+  useEffect(() => {
+    if (isSaveComplete) {
+      saveDoneTimerRef.current = setTimeout(() => {
+        setIsSaveComplete(false);
+      }, 1000);
+    }
+
+    return () => {
+      if (saveDoneTimerRef.current) clearTimeout(saveDoneTimerRef.current);
+    }
+  }, [isSaveComplete]);
 
   // 결과 페이지로 넘아가기 위한 핸들러 함수
   const submitHandler = (data: Out) => {


### PR DESCRIPTION
* 페이지에 들어가면 "저장 완료" 텍스트가 계속 노출되는 이슈 발생
* 사용자가 직접 form에 입력하는 경우인 `form.formState.isDirty`를 사용해, 처음 페이지 입장 시에만 저장 완료 플래그가 변경 되지 않게 코드 수정
* 관심사 분리를 위해 "저장 완료" 여부 값에 대한 `useEffect`로 따로 분리
* 저장 시간 간격 단축 (2초 -> 0.5초)