### PR TITLE
feat: 결과 페이지에서 뒤로가기/다시하기 버튼 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- [![Vercel](https://vercel.com/button)](https://trail-course-guide-printer.vercel.app/) Vercel 배포 후 URL을 여기에 추가하세요 -->
 
 
-[Trailine Prototype Project] GPX 파일과 코스 설명을 입력받아 맞춤형 등산/트레일 코스 가이드 페이지를 생성하고, PNG 파일로 저장 및 인쇄할 수 있는 웹 애플리케이션입니다.
+[Trailine Prototype Project] GPX 파일과 코스 설명을 입력받아 맞춤형 등산/트레일 코스 가이드 페이지를 생성하고, PNG 파일로 저장 및 인쇄할 수 있는 웹 애플리케이션입니다. 후에 개발할 메인 서비스인 Trailine의 초석이 될 프로젝트입니다.
 
 ## Demo
 

--- a/src/app/guide-generator/result/page.tsx
+++ b/src/app/guide-generator/result/page.tsx
@@ -4,9 +4,16 @@ import CourseGuideComponent from '@/components/guide-generator/CourseGuideCompon
 import {Button} from '@/components/ui/button';
 import {useRef} from 'react';
 import * as htmlToImage from 'html-to-image';
+import {useGenerateGuideStep} from '@/stores/guide-generator/generate-guide-step';
+import {UPLOAD_GPX_PAGE} from '@/types/generate-step';
+import {useRouter} from 'next/navigation';
+import {useCourse} from '@/stores/guide-generator/course';
 
 const GuideGeneratorResultPage = () => {
   const ref = useRef<HTMLDivElement>(null);
+  const setStepCode = useGenerateGuideStep((state) => state.setStepCode);
+  const resetCourse = useCourse((state) => state.reset);
+  const router = useRouter();
 
   const exportPNG = async () => {
     if (!ref.current) return;
@@ -22,12 +29,22 @@ const GuideGeneratorResultPage = () => {
     a.click();
   }
 
+  const resetHandler = () => {
+    setStepCode(UPLOAD_GPX_PAGE);
+    resetCourse();
+    router.push('/guide-generator');
+  }
+
   return (
     <div className="layout">
       <div ref={ref}>
         <CourseGuideComponent />
       </div>
-      <Button className="w-full" onClick={exportPNG}>PNG 인쇄</Button>
+      <div className="mt-4 flex flex-col gap-2">
+        <Button className="w-full" onClick={exportPNG}>PNG 인쇄</Button>
+        <Button variant="secondary" className="w-full" onClick={() => router.push('/guide-generator')}>뒤로가기</Button>
+        <Button variant="secondary" className="w-full" onClick={resetHandler}>처음부터 하기</Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🧾 개요
가이드 최종 페이지에서, 뒤로가서 수정한거나, 아니면 처음부터 다시 하고 싶을 때가 있다. 이때 관련된 기능을 구현하려고 한다

## 🔨 기능 추가

* 뒤로가기 버튼 추가
* 처음부터 다시하기 버튼 추가

## ✏️ 세부사항

* 뒤로가기 버튼
  * `navigator`를 통해 이전 페이지 `/guide-generator` 로 돌아간다
* 처음부터 다시하기 버튼  * 
  * store 데이터인 course 정보를 초기화
  * Step을 맨 처음 부분인 `UPLOAD_GPX_PAGE` 로 되돌려놓음

## 🐞 버그 수정
<!-- 수정된 버그나 예외 케이스가 있다면 작성해주세요 -->

## ⚙️ 기타 개선사항
<!-- 구조 개선, 성능 개선, 불필요한 코드 제거 등 기타 변경 사항을 작성해주세요 -->

## 📝 참고사항
<!-- 리뷰어가 알아야 할 추가 정보나 관련 문서, 이슈 링크 등을 작성해주세요 -->