### PR TITLE
chore: pre-release는 데모 페이지에서만 배포할 수 있게 스크립트 수정

### DIFF
--- a/.github/workflows/vercel-release.yml
+++ b/.github/workflows/vercel-release.yml
@@ -3,7 +3,7 @@ name: Deploy to Vercel (Release)
 
 on:
   release:
-    types: [published]   # published 이벤트는 release와 pre-release 모두에 발생
+    types: [released]   # published 이벤트는 release와 pre-release 모두에 발생
 jobs:
   deploy:
     # if: ${{ github.event.release.prerelease == false }}  # pre-release는 스킵  - 0.1.0 이후에만 사용할 것

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trail-course-guide",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 🧾 개요

이전에는 빠른 런칭을 목적으로 Pre 버전도 메인페이지에 배포하게 했는데 ,0.1.0 버전 배포 이후로는 alpha/beta버전은 데모 페이지에서만 배포할 수 있게 해야 한다.

## 🔨 기능 추가
<!-- 새롭게 추가된 기능이 있다면 작성해주세요 -->

## ✏️ 세부사항

vercel-release.yaml에서 release type 대상을 released로 제한을 걸어서, pre-release는 해당 yaml을 작동하제 않게 수정

## 🐞 버그 수정
<!-- 수정된 버그나 예외 케이스가 있다면 작성해주세요 -->

## ⚙️ 기타 개선사항
<!-- 구조 개선, 성능 개선, 불필요한 코드 제거 등 기타 변경 사항을 작성해주세요 -->

## 📝 참고사항
<!-- 리뷰어가 알아야 할 추가 정보나 관련 문서, 이슈 링크 등을 작성해주세요 -->